### PR TITLE
fixed removal of imports that appears after a comment in the imports

### DIFF
--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -213,6 +213,7 @@ class Imports(object):
                     index = potential_end_index
                     potential_end_index = -1
                 ranges.append((size, start, index))
+
                 start = None
                 size = 0
                 if explicit:
@@ -229,7 +230,7 @@ class Imports(object):
             index, token = it.next()
 
             if token[1] not in ('import', 'from') and token[1].strip():
-                break
+                continue
 
             type = token[1]
             if type in ('import', 'from'):

--- a/importmagic/importer_test.py
+++ b/importmagic/importer_test.py
@@ -171,6 +171,29 @@ def test_imports_dont_delete_trailing_comments(index):
         ''').strip() == new_src.strip()
 
 
+def test_imports_dont_delete_imports_after_middle_comments(index):
+    src = dedent('''
+        import sys
+        # Some comment
+        import json
+
+        def func(n):
+            print(basename(n))
+            print(json)
+        ''').strip()
+    scope = Scope.from_source(src)
+    new_src = update_imports(src, index, *scope.find_unresolved_and_unreferenced_symbols())
+    assert dedent('''
+        import json
+        from os.path import basename
+
+
+        def func(n):
+            print(basename(n))
+            print(json)
+        ''').strip() == new_src.strip()
+
+
 def test_imports_removes_unused(index):
     src = dedent('''
         import sys


### PR DESCRIPTION
When there are imports after a comment in the imports block, they get removed so for example:

``` python
import re
# some random comment
import sys

def main():
    print(sys.path)
    print(os.uname())
```

Get translated to

``` python
import os

def main():
    print(sys.path)
    print(os.uname())
```

This commit fixes this behavior but the comment is still gone
