### PR TITLE
Handle python 3 '...' tokens

### DIFF
--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -273,8 +273,9 @@ class Imports(object):
             type = token[1]
             if type in ('import', 'from'):
                 tokens = it.until(tokenize.NEWLINE)
-                tokens = [t[1] for i, t in tokens
-                          if t[0] == tokenize.NAME or t[1] in ',.']
+                tokens = [
+                    t[1] for i, t in tokens
+                    if t[0] == tokenize.NAME or t[1] in (',', '.', '...')]
                 tokens.reverse()
                 self._parse_import(type, tokens)
 


### PR DESCRIPTION
For some reason here in python 3, when I have imports with several dots they are grouped by 3 (like an ellipsis):
```bash
$ python -c "import tokenize,io;print([t[1] for t in tokenize.generate_tokens(io.StringIO('from ....app import app').readline)])"
['from', '...', '.', 'app', 'import', 'app', '']
```
this leads to imports not containing all the needed dots.

This PR seems to fix this problem.