### PR TITLE
Change the max default line length from 80 to 79

### DIFF
--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -72,7 +72,7 @@ LOCATION_ORDER = 'FS3L'
 class Imports(object):
 
     _style = {'multiline': 'parentheses',
-              'max_columns': 80,
+              'max_columns': 79,
     }
 
     def __init__(self, index, source):


### PR DESCRIPTION
Follow [Maximum Line Length rule](http://legacy.python.org/dev/peps/pep-0008/#maximum-line-length) defined in PEP8.