### PR TITLE
Add ability to use tabs as indentation character

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Configuring import styles
 1. Using `importmagic.Imports`.
 
 ```python
-imports = importmagic.Imports.set_style(multiline='backslash', max_columns=80)
+imports = importmagic.Imports.set_style(multiline='backslash', max_columns=80, indent_with_tabs=True)
 ```
 
 `multiline` takes `backlslash` or `parentheses`.
@@ -96,6 +96,7 @@ Add configuration to setup.cfg
 [importmagic]
 multiline = 'parentheses'
 max_columns = 120
+indent_with_tabs = 1
 ```
 
 and pass root directory to importmagic

--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -78,7 +78,11 @@ PROJECT_CONFIG_FILE = 'setup.cfg'
 
 class Imports(object):
 
-    _style = {'multiline': 'parentheses', 'max_columns': 79}
+    _style = {
+		'multiline': 'parentheses',
+		'max_columns': 79,
+		'indent_with_tabs': False,
+	}
 
     def __init__(self, index, source, root_dir=None):
         self._imports = set()
@@ -107,6 +111,8 @@ class Imports(object):
             style['multiline'] = imp_cfg['multiline']
         if imp_cfg['max_columns']:
             style['max_columns'] = int(imp_cfg['max_columns'])
+        if config.getboolean('importmagic', 'indent_with_tabs'):
+            style['indent_with_tabs'] = True
         return style
 
     def add_import(self, name, alias=None):
@@ -166,7 +172,7 @@ class Imports(object):
                             # Use a backslash
                             line_tail = ', \\\n'
                         out.write(line + imported_items + line_tail)
-                        line = '    '
+                        line = '\t' if self._style['indent_with_tabs'] else '    '
                         line_len = len(line) + len(clause) + 2
                         line_pieces = [clause]
                     else:

--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -79,10 +79,10 @@ PROJECT_CONFIG_FILE = 'setup.cfg'
 class Imports(object):
 
     _style = {
-		'multiline': 'parentheses',
-		'max_columns': 79,
-		'indent_with_tabs': False,
-	}
+        'multiline': 'parentheses',
+        'max_columns': 79,
+        'indent_with_tabs': False,
+    }
 
     def __init__(self, index, source, root_dir=None):
         self._imports = set()

--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -100,7 +100,7 @@ class Imports(object):
         style = {}
         cfg_path = os.path.join(self._root_dir, PROJECT_CONFIG_FILE)
         config = ConfigParser()
-        config.read([cfg_path])
+        config.read(cfg_path)
         imp_cfg = config['importmagic']
 
         if imp_cfg['multiline']:

--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -101,7 +101,7 @@ class Imports(object):
         cfg_path = os.path.join(self._root_dir, PROJECT_CONFIG_FILE)
         config = ConfigParser()
         config.read(cfg_path)
-        imp_cfg = config['importmagic']
+        imp_cfg = dict(config.items('importmagic'))
 
         if imp_cfg['multiline']:
             style['multiline'] = imp_cfg['multiline']

--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -5,7 +5,7 @@ import tokenize
 from collections import defaultdict
 try:
     from ConfigParser import ConfigParser
-except:
+except ImportError:
     from configparser import ConfigParser
 
 from importmagic.six import StringIO


### PR DESCRIPTION
By the way, I have have fixed and written a test for the get_style_from_config() method that did not work with Python 2.