### PR TITLE
Prevent single trailing symbol with max_columns

### DIFF
--- a/importmagic/importer.py
+++ b/importmagic/importer.py
@@ -163,14 +163,14 @@ class Imports(object):
                     if next_len > self._style['max_columns']:
                         imported_items = ', '.join(line_pieces)
                         if self._style['multiline'] == 'parentheses':
-                            line_tail = ',\n'
+                            line_tail = ',\n' if imported_items else '\n'
                             if not paren_used:
                                 line += '('
                                 paren_used = True
                             line_pieces.append('\n')
                         else:
                             # Use a backslash
-                            line_tail = ', \\\n'
+                            line_tail = ', \\\n' if imported_items else '\\\n'
                         out.write(line + imported_items + line_tail)
                         line = '\t' if self._style['indent_with_tabs'] else '    '
                         line_len = len(line) + len(clause) + 2

--- a/importmagic/importer_test.py
+++ b/importmagic/importer_test.py
@@ -301,7 +301,7 @@ def test_importer_wrapping_escaped_longer(index):
     Imports.set_style(multiline='backslash', max_columns=80, indent_with_tabs=False)
     src = dedent('''
         from injector import Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum
-        from waffle import stuff
+        from module_with_long_name.classes.some_prefix.another_prefix.waffle import stuff
 
         Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum, stuff
         ''').strip()
@@ -309,7 +309,8 @@ def test_importer_wrapping_escaped_longer(index):
         from injector import Binder, Injector, InstanceProvider, Key, MappingKey, \\
             Module, Scope, ScopeDecorator, SequenceKey, bar, baz, cux, foo, imported, \\
             inject, ipsum, lorem, more, provides, singleton, things
-        from waffle import stuff
+        from module_with_long_name.classes.some_prefix.another_prefix.waffle import \\
+            stuff
 
 
         Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum, stuff
@@ -367,7 +368,7 @@ def test_importer_wrapping_parentheses_longer(index):
     Imports.set_style(multiline='parentheses', max_columns=80, indent_with_tabs=False)
     src = dedent('''
         from injector import Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum
-        from waffle import stuff
+        from module_with_long_name.classes.some_prefix.another_prefix.waffle import stuff
 
         Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum, stuff
         ''').strip()
@@ -375,7 +376,8 @@ def test_importer_wrapping_parentheses_longer(index):
         from injector import (Binder, Injector, InstanceProvider, Key, MappingKey,
             Module, Scope, ScopeDecorator, SequenceKey, bar, baz, cux, foo, imported,
             inject, ipsum, lorem, more, provides, singleton, things)
-        from waffle import stuff
+        from module_with_long_name.classes.some_prefix.another_prefix.waffle import (
+            stuff)
 
 
         Binder, Injector, InstanceProvider, Key, MappingKey, Module, Scope, ScopeDecorator, SequenceKey, inject, provides, singleton, more, things, imported, foo, bar, baz, cux, lorem, ipsum, stuff


### PR DESCRIPTION
Hello!

When I try import module from long path I will get unnecessary trailing symbol.

For example, when I set `max_columns=80` and try to import `stuff` from `module_with_long_name.classes.some_prefix.another_prefix.waffle` I will get this:
```
from module_with_long_name.classes.some_prefix.another_prefix.waffle import ,
    stuff
```

I hope that I solved this problem in this PR.
