### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 sudo: false
 python:
@@ -5,4 +8,8 @@ python:
   - 3.3
   - 3.4
   - 3.5
+
+matrix:
+    allow_failures:
+       - python: 3.3    #EOL
 script: "env python ./runtests.py"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/importmagic/builds/191757322 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!